### PR TITLE
Return [] from listRevisions when no table exists

### DIFF
--- a/lib/deploy-client.js
+++ b/lib/deploy-client.js
@@ -36,26 +36,33 @@ function createTable(tableName) {
 }
 
 function listRevisions(tableName) {
-  return this.knex(tableName)
-    .orderBy('created_at', 'desc')
-    .select('key', 'gitsha', 'deployer', 'description', 'is_active', 'created_at')
-    .map(row => {
-      row.revision = row.key;
-      delete row.key;
-
-      if (row.gitsha) {
-        row.version = row.gitsha.reduce((memo, b) =>
-          memo + (b < 16 ? '0' : '') + b.toString(16), '');
+  return this.knex.schema.hasTable(tableName)
+    .then(exists => {
+      if (!exists) {
+        return [];
       }
-      delete row.gitsha;
 
-      row.active = !!row.is_active;
-      delete row.is_active;
+      return this.knex(tableName)
+        .orderBy('created_at', 'desc')
+        .select('key', 'gitsha', 'deployer', 'description', 'is_active', 'created_at')
+        .map(row => {
+          row.revision = row.key;
+          delete row.key;
 
-      row.timestamp = row.created_at;
-      delete row.created_at;
+          if (row.gitsha) {
+            row.version = row.gitsha.reduce((memo, b) =>
+              memo + (b < 16 ? '0' : '') + b.toString(16), '');
+          }
+          delete row.gitsha;
 
-      return row;
+          row.active = !!row.is_active;
+          delete row.is_active;
+
+          row.timestamp = row.created_at;
+          delete row.created_at;
+
+          return row;
+        });
     });
 }
 

--- a/tests/unit/deploy-client-test.js
+++ b/tests/unit/deploy-client-test.js
@@ -142,6 +142,14 @@ describe('DeployClient private methods', function() {
   describe('#listRevisions()', function() {
     const listRevisions = subject.__get__('listRevisions');
 
+    it('resolves to an empty array if no table exists', function() {
+      return listRevisions.call({ knex }, 'test-not-present')
+        .then(revisions => {
+          assert.isArray(revisions);
+          assert.lengthOf(revisions, 0);
+        });
+    });
+
     it('resolves to an empty array if none', function() {
       return listRevisions.call({ knex }, 'test')
         .then(revisions => {


### PR DESCRIPTION
listRevisions runs before we’ve had a chance to setup the table on the first deploy and so fails.

This lets it return successfully so that the table can be setup later in the deploy.

Alternatively we could conditionally create the table?