### PR TITLE
fix: add core-object as an explicit dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   "author": "Mike Pastore <mike@oobak.org>",
   "license": "MIT",
   "dependencies": {
+    "core-object": "^3.1.5",
     "bluebird": "~3.5.0",
     "ember-cli-deploy-plugin": "^0.2.9",
     "knex": ">= 0.12.9 < 0.14"


### PR DESCRIPTION
Currently using npm 6 doesn't install core-object, at least not where it needs to be. Having this an explicit dependency and not assuming ember-cli will bring it along or put it in the right place is our best bet.